### PR TITLE
nested computed

### DIFF
--- a/src/computed.ts
+++ b/src/computed.ts
@@ -1,4 +1,4 @@
-import { effect } from "./effect";
+import { effect, track, trigger } from "./effect";
 
 export function computed(getter) {
     let dirty = true;
@@ -6,7 +6,9 @@ export function computed(getter) {
     const effectFn = effect(getter, {
         lazy: true,
         scheduler() {
-            dirty = true
+            dirty = true;
+            // trigger
+            trigger(res, 'value')
         }
     })
 
@@ -15,6 +17,7 @@ export function computed(getter) {
             if (dirty) {
                 cacheVal = effectFn();
                 dirty = false;
+                track(res, 'value')
             }
             return cacheVal
         }

--- a/src/tests/compute.spec.ts
+++ b/src/tests/compute.spec.ts
@@ -1,5 +1,6 @@
 import { reactive } from "../reactive"
 import { computed } from "../computed"
+import { effect } from "../effect"
 
 describe('computed', () => {
     it('should return updated value', () => {
@@ -14,6 +15,30 @@ describe('computed', () => {
             const obj = reactive({ foo: 1, bar: 2 })
             const sumRes = computed(() => obj.foo + obj.bar)
             expect(sumRes.value).toBe(3);  // 3
+        }),
+
+        it('nested computed', () => {
+            const value = reactive({ foo: 1 })
+            const cValue = computed(() => value.foo)
+            let val = 0
+            effect(() => {
+                val = cValue.value
+            })
+            expect(val).toBe(1)
+            value.foo++;
+            expect(cValue.value).toBe(2)
+            expect(val).toBe(2)
+        }),
+
+        it('should work when chained', () => {
+            const value = reactive({ foo: 0 })
+            const c1 = computed(() => value.foo)
+            const c2 = computed(() => c1.value + 1)
+            expect(c2.value).toBe(1)
+            expect(c1.value).toBe(0)
+            value.foo++
+            expect(c2.value).toBe(2)
+            expect(c1.value).toBe(1)
         })
 
 }) 


### PR DESCRIPTION
实现嵌套类型的computed
`
const sumRes = computed(() => obj.foo + obj.bar)
 effect(() => {console.log(sumRes.value)})
// 修改 obj.foo 的值
obj.foo++
`
这里在修改foo的时候需要手动触发一下依赖，在读取计算属性的value的时候依赖收集
最后建立的拓扑关系如下：
`computed(obj)
     └── value
         └── effectFn`

